### PR TITLE
Loading stored impression and code review fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,8 @@ type Configuration struct {
 	GDPR                 GDPR               `mapstructure:"gdpr"`
 	CurrencyConverter    CurrencyConverter  `mapstructure:"currency_converter"`
 	DefReqConfig         DefReqConfig       `mapstructure:"default_request"`
+
+	VideoStoredRequestRequired bool `mapstructure:"video_stored_request_required"`
 }
 
 type HTTPClient struct {

--- a/endpoints/openrtb2/sample-requests/video/video_valid_sample.json
+++ b/endpoints/openrtb2/sample-requests/video/video_valid_sample.json
@@ -14,12 +14,12 @@
       {
         "podid": 1,
         "adpoddurationsec": 180,
-        "configid": "12971250"
+        "configid": "fba10607-0c12-43d1-ad07-b8a513bc75d6"
       },
       {
         "podid": 2,
         "adpoddurationsec": 150,
-        "configid": "12971250"
+        "configid": "8b452b41-2681-4a20-9086-6f16ffad7773"
       }
     ]
   },

--- a/endpoints/openrtb2/sample-requests/video/video_valid_sample_different_durations.json
+++ b/endpoints/openrtb2/sample-requests/video/video_valid_sample_different_durations.json
@@ -15,12 +15,12 @@
       {
         "podid": 1,
         "adpoddurationsec": 180,
-        "configid": "12971250"
+        "configid": "8b452b41-2681-4a20-9086-6f16ffad7773"
       },
       {
         "podid": 2,
         "adpoddurationsec": 150,
-        "configid": "12971250"
+        "configid": "fba10607-0c12-43d1-ad07-b8a513bc75d6"
       }
     ]
   },

--- a/endpoints/openrtb2/video_auction_test.go
+++ b/endpoints/openrtb2/video_auction_test.go
@@ -186,7 +186,7 @@ func mockDeps(t *testing.T, ex *mockExchangeVideo) *endpointDeps {
 	edep := &endpointDeps{
 		ex,
 		newParamsValidator(t),
-		&mockStoredReqFetcher{},
+		&mockVideoStoredReqFetcher{},
 		&config.Configuration{MaxRequestSize: maxSize},
 		theMetrics,
 		analyticsConf.NewPBSAnalytics(&config.Analytics{}),
@@ -197,6 +197,13 @@ func mockDeps(t *testing.T, ex *mockExchangeVideo) *endpointDeps {
 		nil}
 
 	return edep
+}
+
+type mockVideoStoredReqFetcher struct {
+}
+
+func (cf mockVideoStoredReqFetcher) FetchRequests(ctx context.Context, requestIDs []string, impIDs []string) (requestData map[string]json.RawMessage, impData map[string]json.RawMessage, errs []error) {
+	return testVideoStoredRequestData, testVideoStoredImpData, nil
 }
 
 type mockExchangeVideo struct {
@@ -228,4 +235,33 @@ func (m *mockExchangeVideo) HoldAuction(ctx context.Context, bidRequest *openrtb
 			},
 		}},
 	}, nil
+}
+
+var testVideoStoredImpData = map[string]json.RawMessage{
+	"fba10607-0c12-43d1-ad07-b8a513bc75d6": json.RawMessage(`{"ext": {"appnexus": {"placementId": 14997137}}}`),
+	"8b452b41-2681-4a20-9086-6f16ffad7773": json.RawMessage(`{"ext": {"appnexus": {"placementId": 15016213}}}`),
+	"87d82a45-35c3-46cc-9315-2e3eeb91d0f2": json.RawMessage(`{"ext": {"appnexus": {"placementId": 15062775}}}`),
+}
+
+var testVideoStoredRequestData = map[string]json.RawMessage{
+	"2": json.RawMessage(`{
+		"tmax": 500,
+		"ext": {
+			"prebid": {
+				"targeting": {
+					"pricegranularity": "low"
+				}
+			}
+		}
+	}`),
+	"3": json.RawMessage(`{
+                "tmax": 500,
+                "ext": {
+                        "prebid": {
+                                "targeting": {
+                                        "pricegranularity": "low"
+                                }
+                        }
+                }}
+        }`),
 }

--- a/openrtb_ext/bid_request_video.go
+++ b/openrtb_ext/bid_request_video.go
@@ -266,14 +266,3 @@ type SimplifiedVideo struct {
 	//  protocols
 	Protocols []openrtb.Protocol `json:"protocols"`
 }
-
-type StoredRequestId struct {
-
-	// Attribute:
-	//   storedrequestid
-	// Type:
-	//   string; required
-	// Description:
-	//   Unique ID of the stored request
-	StoredRequestId string `json:"storedrequestid"`
-}


### PR DESCRIPTION
-Added VideoStoredRequestRequired config parameter to set if stored request id is required in video endpoint
-Added handling of VideoStoredRequestRequired in auction endpoint
-Added function to load stored impressions
-Minor refactoring of getVideoStoredRequestId - now it uses jasonparser
-Removed validation of AccountId
-Unit tests fixes